### PR TITLE
[flake8-import-conventions] Add import `numpy.typing as npt` to default `flake8-import-conventions.aliases`

### DIFF
--- a/crates/red_knot_python_semantic/mdtest.py
+++ b/crates/red_knot_python_semantic/mdtest.py
@@ -155,6 +155,7 @@ class MDTestRunner:
 
     def watch(self) -> Never:
         self._recompile_tests("Compiling tests...", message_on_success=False)
+        self._run_mdtest()
         self.console.print("[dim]Ready to watch for changes...[/dim]")
 
         for changes in watch(CRATE_ROOT):

--- a/crates/red_knot_python_semantic/resources/mdtest/annotations/tuple.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/annotations/tuple.md
@@ -1,0 +1,15 @@
+# Tuple
+
+## `Never`
+
+If a tuple type contains a `Never` element, then it is eagerly simplified to `Never` which means
+that a tuple type containing `Never` is disjoint from any other tuple type.
+
+```py
+from typing_extensions import Never
+
+def _(x: tuple[Never], y: tuple[int, Never], z: tuple[Never, int]):
+    reveal_type(x)  # revealed: Never
+    reveal_type(y)  # revealed: Never
+    reveal_type(z)  # revealed: Never
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/directives/cast.md
@@ -38,3 +38,14 @@ def function_returning_any() -> Any:
 # error: [redundant-cast] "Value is already of type `Any`"
 cast(Any, function_returning_any())
 ```
+
+Complex type expressions (which may be unsupported) do not lead to spurious `[redundant-cast]`
+diagnostics.
+
+```py
+from typing import Callable
+
+def f(x: Callable[[dict[str, int]], None], y: tuple[dict[str, int]]):
+    a = cast(Callable[[list[bytes]], None], x)
+    b = cast(tuple[list[bytes]], y)
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -61,7 +61,7 @@ static_assert(is_disjoint_from(B2, FinalSubclass))
 ## Tuple types
 
 ```py
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 from knot_extensions import TypeOf, is_disjoint_from, static_assert
 
 static_assert(is_disjoint_from(tuple[()], TypeOf[object]))
@@ -352,4 +352,30 @@ class UsesMeta1(metaclass=Meta1): ...
 class UsesMeta2(metaclass=Meta2): ...
 
 static_assert(is_disjoint_from(type[UsesMeta1], type[UsesMeta2]))
+```
+
+## Callables
+
+No two callable types are disjoint because there exists a non-empty callable type
+`(*args: object, **kwargs: object) -> Never` that is a subtype of all fully static callable types.
+As such, for any two callable types, it is possible to conceive of a runtime callable object that
+would inhabit both types simultaneously.
+
+```py
+from knot_extensions import CallableTypeOf, is_disjoint_from, static_assert
+from typing_extensions import Callable, Literal, Never
+
+def mixed(a: int, /, b: str, *args: int, c: int = 2, **kwargs: int) -> None: ...
+
+static_assert(not is_disjoint_from(Callable[[], Never], CallableTypeOf[mixed]))
+static_assert(not is_disjoint_from(Callable[[int, str], float], CallableTypeOf[mixed]))
+
+# Using gradual form
+static_assert(not is_disjoint_from(Callable[..., None], Callable[[], None]))
+static_assert(not is_disjoint_from(Callable[..., None], Callable[..., None]))
+static_assert(not is_disjoint_from(Callable[..., None], Callable[[Literal[1]], None]))
+
+# Using `Never`
+static_assert(not is_disjoint_from(Callable[[], Never], Callable[[], Never]))
+static_assert(not is_disjoint_from(Callable[[Never], str], Callable[[Never], int]))
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -240,4 +240,15 @@ static_assert(not is_equivalent_to(CallableTypeOf[f12], CallableTypeOf[f13]))
 static_assert(not is_equivalent_to(CallableTypeOf[f13], CallableTypeOf[f12]))
 ```
 
+### Unions containing `Callable`s containing unions
+
+Differently ordered unions inside `Callable`s inside unions can still be equivalent:
+
+```py
+from typing import Callable
+from knot_extensions import is_equivalent_to, static_assert
+
+static_assert(is_equivalent_to(int | Callable[[int | str], None], Callable[[str | int], None] | int))
+```
+
 [the equivalence relation]: https://typing.readthedocs.io/en/latest/spec/glossary.html#term-equivalent

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_single_valued.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_single_valued.md
@@ -3,8 +3,9 @@
 A type is single-valued iff it is not empty and all inhabitants of it compare equal.
 
 ```py
+import types
 from typing_extensions import Any, Literal, LiteralString, Never, Callable
-from knot_extensions import is_single_valued, static_assert
+from knot_extensions import is_single_valued, static_assert, TypeOf
 
 static_assert(is_single_valued(None))
 static_assert(is_single_valued(Literal[True]))
@@ -25,4 +26,11 @@ static_assert(not is_single_valued(tuple[None, int]))
 
 static_assert(not is_single_valued(Callable[..., None]))
 static_assert(not is_single_valued(Callable[[int, str], None]))
+
+class A:
+    def method(self): ...
+
+static_assert(is_single_valued(TypeOf[A().method]))
+static_assert(is_single_valued(TypeOf[types.FunctionType.__get__]))
+static_assert(is_single_valued(TypeOf[A.method.__get__]))
 ```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_singleton.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/is_singleton.md
@@ -133,3 +133,29 @@ from knot_extensions import static_assert, is_singleton
 reveal_type(types.NotImplementedType)  # revealed: Unknown | Literal[_NotImplementedType]
 static_assert(not is_singleton(types.NotImplementedType))
 ```
+
+### Callables
+
+We currently treat the type of `types.FunctionType.__get__` as a singleton type that has its own
+dedicated variant in the `Type` enum. That variant should be understood as a singleton type, but the
+similar variants `Type::BoundMethod` and `Type::MethodWrapperDunderGet` should not be; nor should
+`Type::Callable` types.
+
+If we refactor `Type` in the future to get rid of some or all of these `Type` variants, the
+assertion that the type of `types.FunctionType.__get__` is a singleton type does not necessarily
+have to hold true; it's more of a unit test for our current implementation.
+
+```py
+import types
+from typing import Callable
+from knot_extensions import static_assert, is_singleton, TypeOf
+
+class A:
+    def method(self): ...
+
+static_assert(is_singleton(TypeOf[types.FunctionType.__get__]))
+
+static_assert(not is_singleton(Callable[[], None]))
+static_assert(not is_singleton(TypeOf[A().method]))
+static_assert(not is_singleton(TypeOf[A.method.__get__]))
+```

--- a/crates/red_knot_python_semantic/resources/mdtest/type_properties/truthiness.md
+++ b/crates/red_knot_python_semantic/resources/mdtest/type_properties/truthiness.md
@@ -120,3 +120,26 @@ static_assert(is_subtype_of(typing.TypeAliasType, AlwaysTruthy))
 static_assert(is_subtype_of(types.MethodWrapperType, AlwaysTruthy))
 static_assert(is_subtype_of(types.WrapperDescriptorType, AlwaysTruthy))
 ```
+
+### `Callable` types always have ambiguous truthiness
+
+```py
+from typing import Callable
+
+def f(x: Callable, y: Callable[[int], str]):
+    reveal_type(bool(x))  # revealed: bool
+    reveal_type(bool(y))  # revealed: bool
+```
+
+But certain callable single-valued types are known to be always truthy:
+
+```py
+from types import FunctionType
+
+class A:
+    def method(self): ...
+
+reveal_type(bool(A().method))  # revealed: Literal[True]
+reveal_type(bool(f.__get__))  # revealed: Literal[True]
+reveal_type(bool(FunctionType.__get__))  # revealed: Literal[True]
+```

--- a/crates/red_knot_python_semantic/src/types.rs
+++ b/crates/red_knot_python_semantic/src/types.rs
@@ -4644,6 +4644,10 @@ impl<'db> GeneralCallableType<'db> {
             iter_other: other_signature.parameters().iter(),
         };
 
+        // Collect all the standard parameters that have only been matched against a variadic
+        // parameter which means that the keyword variant is still unmatched.
+        let mut other_keywords = Vec::new();
+
         loop {
             let Some(next_parameter) = parameters.next() else {
                 // All parameters have been checked or both the parameter lists were empty. In
@@ -4653,6 +4657,14 @@ impl<'db> GeneralCallableType<'db> {
 
             match next_parameter {
                 EitherOrBoth::Left(self_parameter) => match self_parameter.kind() {
+                    ParameterKind::KeywordOnly { .. } | ParameterKind::KeywordVariadic { .. }
+                        if !other_keywords.is_empty() =>
+                    {
+                        // If there are any unmatched keyword parameters in `other`, they need to
+                        // be checked against the keyword-only / keyword-variadic parameters that
+                        // will be done after this loop.
+                        break;
+                    }
                     ParameterKind::PositionalOnly { default_type, .. }
                     | ParameterKind::PositionalOrKeyword { default_type, .. }
                     | ParameterKind::KeywordOnly { default_type, .. } => {
@@ -4727,12 +4739,23 @@ impl<'db> GeneralCallableType<'db> {
                             }
                         }
 
-                        (ParameterKind::Variadic { .. }, ParameterKind::PositionalOnly { .. }) => {
+                        (
+                            ParameterKind::Variadic { .. },
+                            ParameterKind::PositionalOnly { .. }
+                            | ParameterKind::PositionalOrKeyword { .. },
+                        ) => {
                             if !check_types(
                                 other_parameter.annotated_type(),
                                 self_parameter.annotated_type(),
                             ) {
                                 return false;
+                            }
+
+                            if matches!(
+                                other_parameter.kind(),
+                                ParameterKind::PositionalOrKeyword { .. }
+                            ) {
+                                other_keywords.push(other_parameter);
                             }
 
                             // We've reached a variadic parameter in `self` which means there can
@@ -4749,14 +4772,17 @@ impl<'db> GeneralCallableType<'db> {
                                 let Some(other_parameter) = parameters.peek_other() else {
                                     break;
                                 };
-                                if !matches!(
-                                    other_parameter.kind(),
+                                match other_parameter.kind() {
+                                    ParameterKind::PositionalOrKeyword { .. } => {
+                                        other_keywords.push(other_parameter);
+                                    }
                                     ParameterKind::PositionalOnly { .. }
-                                        | ParameterKind::Variadic { .. }
-                                ) {
-                                    // Any other parameter kind cannot be checked against a
-                                    // variadic parameter and is deferred to the next iteration.
-                                    break;
+                                    | ParameterKind::Variadic { .. } => {}
+                                    _ => {
+                                        // Any other parameter kind cannot be checked against a
+                                        // variadic parameter and is deferred to the next iteration.
+                                        break;
+                                    }
                                 }
                                 if !check_types(
                                     other_parameter.annotated_type(),
@@ -4828,9 +4854,13 @@ impl<'db> GeneralCallableType<'db> {
             }
         }
 
-        for other_parameter in other_parameters {
+        for other_parameter in other_keywords.into_iter().chain(other_parameters) {
             match other_parameter.kind() {
                 ParameterKind::KeywordOnly {
+                    name: other_name,
+                    default_type: other_default,
+                }
+                | ParameterKind::PositionalOrKeyword {
                     name: other_name,
                     default_type: other_default,
                 } => {

--- a/crates/red_knot_python_semantic/src/types/class_base.rs
+++ b/crates/red_knot_python_semantic/src/types/class_base.rs
@@ -73,6 +73,9 @@ impl<'db> ClassBase<'db> {
             | Type::BooleanLiteral(_)
             | Type::FunctionLiteral(_)
             | Type::Callable(..)
+            | Type::BoundMethod(_)
+            | Type::MethodWrapperDunderGet(_)
+            | Type::WrapperDescriptorDunderGet
             | Type::BytesLiteral(_)
             | Type::IntLiteral(_)
             | Type::StringLiteral(_)

--- a/crates/red_knot_python_semantic/src/types/display.rs
+++ b/crates/red_knot_python_semantic/src/types/display.rs
@@ -9,8 +9,8 @@ use ruff_python_literal::escape::AsciiEscape;
 use crate::types::class_base::ClassBase;
 use crate::types::signatures::{Parameter, Parameters, Signature};
 use crate::types::{
-    CallableType, ClassLiteralType, InstanceType, IntersectionType, KnownClass, StringLiteralType,
-    Type, UnionType,
+    ClassLiteralType, InstanceType, IntersectionType, KnownClass, StringLiteralType, Type,
+    UnionType,
 };
 use crate::Db;
 use rustc_hash::FxHashMap;
@@ -90,10 +90,8 @@ impl Display for DisplayRepresentation<'_> {
             },
             Type::KnownInstance(known_instance) => f.write_str(known_instance.repr(self.db)),
             Type::FunctionLiteral(function) => f.write_str(function.name(self.db)),
-            Type::Callable(CallableType::General(callable)) => {
-                callable.signature(self.db).display(self.db).fmt(f)
-            }
-            Type::Callable(CallableType::BoundMethod(bound_method)) => {
+            Type::Callable(callable) => callable.signature(self.db).display(self.db).fmt(f),
+            Type::BoundMethod(bound_method) => {
                 write!(
                     f,
                     "<bound method `{method}` of `{instance}`>",
@@ -101,14 +99,14 @@ impl Display for DisplayRepresentation<'_> {
                     instance = bound_method.self_instance(self.db).display(self.db)
                 )
             }
-            Type::Callable(CallableType::MethodWrapperDunderGet(function)) => {
+            Type::MethodWrapperDunderGet(function) => {
                 write!(
                     f,
                     "<method-wrapper `__get__` of `{function}`>",
                     function = function.name(self.db)
                 )
             }
-            Type::Callable(CallableType::WrapperDescriptorDunderGet) => {
+            Type::WrapperDescriptorDunderGet => {
                 f.write_str("<wrapper-descriptor `__get__` of `function` objects>")
             }
             Type::Union(union) => union.display(self.db).fmt(f),
@@ -423,9 +421,7 @@ struct DisplayMaybeParenthesizedType<'db> {
 
 impl Display for DisplayMaybeParenthesizedType<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        if let Type::Callable(CallableType::General(_) | CallableType::MethodWrapperDunderGet(_)) =
-            self.ty
-        {
+        if let Type::Callable(_) | Type::MethodWrapperDunderGet(_) = self.ty {
             write!(f, "({})", self.ty.display(self.db))
         } else {
             self.ty.display(self.db).fmt(f)

--- a/crates/red_knot_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/red_knot_python_semantic/src/types/property_tests/type_generation.rs
@@ -1,8 +1,8 @@
 use crate::db::tests::TestDb;
 use crate::symbol::{builtins_symbol, known_module_symbol};
 use crate::types::{
-    BoundMethodType, CallableType, IntersectionBuilder, KnownClass, KnownInstanceType,
-    SubclassOfType, TupleType, Type, UnionType,
+    BoundMethodType, IntersectionBuilder, KnownClass, KnownInstanceType, SubclassOfType, TupleType,
+    Type, UnionType,
 };
 use crate::{Db, KnownModule};
 use quickcheck::{Arbitrary, Gen};
@@ -53,11 +53,11 @@ fn create_bound_method<'db>(
     function: Type<'db>,
     builtins_class: Type<'db>,
 ) -> Type<'db> {
-    Type::Callable(CallableType::BoundMethod(BoundMethodType::new(
+    Type::BoundMethod(BoundMethodType::new(
         db,
         function.expect_function_literal(),
         builtins_class.to_instance(db).unwrap(),
-    )))
+    ))
 }
 
 impl Ty {

--- a/crates/red_knot_python_semantic/src/types/signatures.rs
+++ b/crates/red_knot_python_semantic/src/types/signatures.rs
@@ -504,6 +504,12 @@ impl<'db, 'a> IntoIterator for &'a Parameters<'db> {
     }
 }
 
+impl<'db> FromIterator<Parameter<'db>> for Parameters<'db> {
+    fn from_iter<T: IntoIterator<Item = Parameter<'db>>>(iter: T) -> Self {
+        Self::new(iter)
+    }
+}
+
 impl<'db> std::ops::Index<usize> for Parameters<'db> {
     type Output = Parameter<'db>;
 
@@ -590,6 +596,33 @@ impl<'db> Parameter<'db> {
 
     pub(crate) fn type_form(mut self) -> Self {
         self.form = ParameterForm::Type;
+        self
+    }
+
+    pub(crate) fn with_sorted_unions_and_intersections(mut self, db: &'db dyn Db) -> Self {
+        self.annotated_type = self
+            .annotated_type
+            .map(|ty| ty.with_sorted_unions_and_intersections(db));
+
+        self.kind = match self.kind {
+            ParameterKind::PositionalOnly { name, default_type } => ParameterKind::PositionalOnly {
+                name,
+                default_type: default_type.map(|ty| ty.with_sorted_unions_and_intersections(db)),
+            },
+            ParameterKind::PositionalOrKeyword { name, default_type } => {
+                ParameterKind::PositionalOrKeyword {
+                    name,
+                    default_type: default_type
+                        .map(|ty| ty.with_sorted_unions_and_intersections(db)),
+                }
+            }
+            ParameterKind::KeywordOnly { name, default_type } => ParameterKind::KeywordOnly {
+                name,
+                default_type: default_type.map(|ty| ty.with_sorted_unions_and_intersections(db)),
+            },
+            ParameterKind::Variadic { .. } | ParameterKind::KeywordVariadic { .. } => self.kind,
+        };
+
         self
     }
 

--- a/crates/red_knot_python_semantic/src/types/type_ordering.rs
+++ b/crates/red_knot_python_semantic/src/types/type_ordering.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 
 use crate::db::Db;
-use crate::types::CallableType;
 
 use super::{
     class_base::ClassBase, ClassLiteralType, DynamicType, InstanceType, KnownInstanceType,
@@ -62,32 +61,22 @@ pub(super) fn union_or_intersection_elements_ordering<'db>(
         (Type::FunctionLiteral(_), _) => Ordering::Less,
         (_, Type::FunctionLiteral(_)) => Ordering::Greater,
 
-        (
-            Type::Callable(CallableType::BoundMethod(left)),
-            Type::Callable(CallableType::BoundMethod(right)),
-        ) => left.cmp(right),
-        (Type::Callable(CallableType::BoundMethod(_)), _) => Ordering::Less,
-        (_, Type::Callable(CallableType::BoundMethod(_))) => Ordering::Greater,
+        (Type::BoundMethod(left), Type::BoundMethod(right)) => left.cmp(right),
+        (Type::BoundMethod(_), _) => Ordering::Less,
+        (_, Type::BoundMethod(_)) => Ordering::Greater,
 
-        (
-            Type::Callable(CallableType::MethodWrapperDunderGet(left)),
-            Type::Callable(CallableType::MethodWrapperDunderGet(right)),
-        ) => left.cmp(right),
-        (Type::Callable(CallableType::MethodWrapperDunderGet(_)), _) => Ordering::Less,
-        (_, Type::Callable(CallableType::MethodWrapperDunderGet(_))) => Ordering::Greater,
-
-        (
-            Type::Callable(CallableType::WrapperDescriptorDunderGet),
-            Type::Callable(CallableType::WrapperDescriptorDunderGet),
-        ) => Ordering::Equal,
-        (Type::Callable(CallableType::WrapperDescriptorDunderGet), _) => Ordering::Less,
-        (_, Type::Callable(CallableType::WrapperDescriptorDunderGet)) => Ordering::Greater,
-
-        (Type::Callable(CallableType::General(_)), Type::Callable(CallableType::General(_))) => {
-            Ordering::Equal
+        (Type::MethodWrapperDunderGet(left), Type::MethodWrapperDunderGet(right)) => {
+            left.cmp(right)
         }
-        (Type::Callable(CallableType::General(_)), _) => Ordering::Less,
-        (_, Type::Callable(CallableType::General(_))) => Ordering::Greater,
+        (Type::MethodWrapperDunderGet(_), _) => Ordering::Less,
+        (_, Type::MethodWrapperDunderGet(_)) => Ordering::Greater,
+
+        (Type::WrapperDescriptorDunderGet, _) => Ordering::Less,
+        (_, Type::WrapperDescriptorDunderGet) => Ordering::Greater,
+
+        (Type::Callable(left), Type::Callable(right)) => left.cmp(right),
+        (Type::Callable(_), _) => Ordering::Less,
+        (_, Type::Callable(_)) => Ordering::Greater,
 
         (Type::Tuple(left), Type::Tuple(right)) => {
             debug_assert_eq!(*left, left.with_sorted_unions_and_intersections(db));


### PR DESCRIPTION
## Summary
Adds import `numpy.typing as npt` to default in `flake8-import-conventions.aliases`
Resolves #17028

## Test Plan
Manually ran ruff on the altered fixture and also ran `cargo test`